### PR TITLE
Fix for default drive change on some file operations

### DIFF
--- a/RunCPM/abstraction_vstudio.h
+++ b/RunCPM/abstraction_vstudio.h
@@ -127,7 +127,10 @@ void _GetFile(uint16 fcbaddr, uint8* filename)
 {
 	CPM_FCB* F = (CPM_FCB*)&RAM[fcbaddr];
 	uint8 i = 0;
-	*(filename++) = _RamRead(0x0004) + 'A';
+	if (F->dr)
+		*(filename++) = _RamRead(0x0004) + 'A';
+	else
+		*(filename++) = drive[0];
 	*(filename++) = '\\';
 
 	while (i < 8) {


### PR DESCRIPTION
On the following sequence:
- select drive A
- open file from drive B
- read random from drive B
- search for first file on current drive
the search operation is incorrectly performed on drive B, instead of drive A. This patch fixes it.
