### PR TITLE
Fix for ctrl-y in Mac OS X

### DIFF
--- a/RunCPM/abstraction_posix.h
+++ b/RunCPM/abstraction_posix.h
@@ -288,7 +288,8 @@ void _console_init(void)
 
 //	_new_term.c_cc[VQUIT] = 0; /* Pass Ctrl-\ to stdout */
 	_new_term.c_cc[VINTR] = 0; /* Pass Ctrl-c to stdout */
-	_new_term.c_cc[VSUSP] = 0; /* Passe Ctrl-z to stdout */
+	_new_term.c_cc[VSUSP] = 0; /* Pass Ctrl-z to stdout */
+	_new_term.c_cc[VDSUSP] = 0; /* Pass Ctrl-y to stdout */
 
 	tcsetattr(0, TCSANOW, &_new_term); /* Immediate terminal output */
 }


### PR DESCRIPTION
In Darwin build pressing ctrl-y in Wordstar (remove line) and then Enter key causes emulator halt. This fix removes the "delay suspend" signal handling from the terminal.