### PR TITLE
Fixed pattern matching on directory traversing

### DIFF
--- a/RunCPM/abstraction_posix.h
+++ b/RunCPM/abstraction_posix.h
@@ -194,7 +194,7 @@ void dirToFCB(uint8* from, uint8* to)
 		*to = toupper(*from);
 		to++; from++; i++;
 	}
-	while (i < 8) {
+	while (i < 10) {
 		*to = ' ';
 		to++;  i++;
 	}


### PR DESCRIPTION
I copied dirToFCB originally from CPMduino where filename does not have a prefix (A/). So all pattern matching was off by two and in some cases failed on filenames where the name part was < 8 chars.