### PR TITLE
Minor fixes

### DIFF
--- a/RunCPM/Makefile.posix
+++ b/RunCPM/Makefile.posix
@@ -15,7 +15,7 @@ LD = gcc
 
 # Flags to pass to the compiler - add "-g" to include debug information
 CFLAGS = -Wall -O0 -fPIC
-#CFLAGS = -Wall -O0 -g
+#CFLAGS = -Wall -O0 -fPIC -g
 
 # Flags to pass to the linker
 LDFLAGS = -lncurses

--- a/RunCPM/Makefile.posix
+++ b/RunCPM/Makefile.posix
@@ -14,7 +14,7 @@ CC = gcc
 LD = gcc
 
 # Flags to pass to the compiler - add "-g" to include debug information
-CFLAGS = -Wall -O0
+CFLAGS = -Wall -O0 -fPIC
 #CFLAGS = -Wall -O0 -g
 
 # Flags to pass to the linker

--- a/RunCPM/abstraction_posix.h
+++ b/RunCPM/abstraction_posix.h
@@ -290,7 +290,9 @@ void _console_init(void)
 //	_new_term.c_cc[VQUIT] = 0; /* Pass Ctrl-\ to stdout */
 	_new_term.c_cc[VINTR] = 0; /* Pass Ctrl-c to stdout */
 	_new_term.c_cc[VSUSP] = 0; /* Pass Ctrl-z to stdout */
+#ifdef __APPLE__
 	_new_term.c_cc[VDSUSP] = 0; /* Pass Ctrl-y to stdout */
+#endif
 
 	tcsetattr(0, TCSANOW, &_new_term); /* Immediate terminal output */
 }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # RunCPM
 
-RunCPM is a windows 32 bits application which allows you to execute old CP/M 8 bits programs on Windows, Mac OS X, Linux, FreeBSD and Arduino DUE.
+RunCPM is a 32 bits application which allows you to execute old CP/M 8 bits programs on Windows, Mac OS X, Linux, FreeBSD and Arduino DUE.
 If you miss powerful programs like Wordstar, dBaseII, Mbasic and others, then RunCPM is for you.
 
 RunCPM builds on Visual Studio 2013 or later. Posix builds use gcc/llvm.


### PR DESCRIPTION
Should now run on CentOS. Seems that ctrl-y exits emulator on Mac only.