### PR TITLE
Fix for dos debug build

### DIFF
--- a/RunCPM/posix.h
+++ b/RunCPM/posix.h
@@ -133,13 +133,14 @@ int _sys_renamefile(uint8 *filename, uint8 *newname) {
 
 #ifdef DEBUGLOG
 void _sys_logbuffer(uint8 *buffer) {
+	FILE *file;
 #ifdef CONSOLELOG
 	puts((char *)buffer);
 #else
 	uint8 s = 0;
 	while (*(buffer + s))	// Computes buffer size
 		s++;
-	FILE *file = _sys_fopen_a((uint8*)LogName);
+	file = _sys_fopen_a((uint8*)LogName);
 	_sys_fwrite(buffer, 1, s, file);
 	_sys_fclose(file);
 #endif


### PR DESCRIPTION
DJGPP's gcc.exe doesn't like variable declaration and definition mixed up. AFAIK ANSI C doesn't allow it and it's a C++ -ism which many C compilers accept, but DJGPP often complains about that.
Don't know why it works for functions outside DEBUGLOG, though. IMHO it shouldn't work there either. Maybe there is some kind of bug in the compiler itself :)