### PR TITLE
Copy the extension for filenames with all 8 chars

### DIFF
--- a/RunCPM/ccp.h
+++ b/RunCPM/ccp.h
@@ -153,8 +153,8 @@ uint8 _ccp_nameToFCB(uint16 fcb) {
 
 		plen = 8;
 		pad = ' ';
+		ch = toupper(_RamRead(pbuf));
 		while (blen && plen) {
-			ch = toupper(_RamRead(pbuf));
 			if (_ccp_delim(ch)) {
 				break;
 			}
@@ -167,6 +167,7 @@ uint8 _ccp_nameToFCB(uint16 fcb) {
 			}
 			plen--; n++;
 			_RamWrite(fcb++, ch);
+			ch = toupper(_RamRead(pbuf));
 		}
 
 		while (plen--)


### PR DESCRIPTION
The internal CCP will fail on commands such as "ren a.fil=01234567.fil", because the filename 01234567.fil is copied as "01234567<0x20><0x20><0x20>" to the FCB instead of "01234567fil".

This patch fixes this problem. 