### PR TITLE
kbhit() should only return true when data is truly available to read

### DIFF
--- a/RunCPM/abstraction_posix.h
+++ b/RunCPM/abstraction_posix.h
@@ -100,7 +100,7 @@ int _kbhit(void) {
 	pfds[0].fd = STDIN_FILENO;
 	pfds[0].events = POLLIN;
 
-	return poll(pfds, 1, 0);
+	return (poll(pfds, 1, 0) == 1) && (pfds[0].revents & POLLRDNORM);
 }
 
 uint8 _getch(void) {


### PR DESCRIPTION
In certain edge cases on macOS (and possibly other posix platforms?) with RunCPM invocations  such as:

./RunCPM <<EOF
submit cz.sub
exit
EOF

_kbhit() may report that data is available when it isn't because poll() may return -1 to indicate an error and the .revents field may indicate some other event than expected.

This patch makes _kbhit() only return true when data is truly available to read with _getch().