### PR TITLE
Check for all input priorities in kbhit

### DIFF
--- a/RunCPM/abstraction_posix.h
+++ b/RunCPM/abstraction_posix.h
@@ -98,9 +98,9 @@ int _kbhit(void) {
 	struct pollfd pfds[1];
 
 	pfds[0].fd = STDIN_FILENO;
-	pfds[0].events = POLLIN;
+	pfds[0].events = POLLIN | POLLPRI | POLLRDBAND | POLLRDNORM;
 
-	return (poll(pfds, 1, 0) == 1) && (pfds[0].revents & POLLRDNORM);
+	return (poll(pfds, 1, 0) == 1) && (pfds[0].revents & (POLLIN | POLLPRI | POLLRDBAND | POLLRDNORM));
 }
 
 uint8 _getch(void) {


### PR DESCRIPTION
Depending on whether stdin is interactive or not, input may appear at different priorities. All possible priorities should be checked in poll().

This fixes issue #46 