### PR TITLE
Mimic CP/M: update FCB's CR, EX and S2 fields even on some errors from sys_readrand() 

### DIFF
--- a/RunCPM/abstraction_arduino.h
+++ b/RunCPM/abstraction_arduino.h
@@ -207,8 +207,7 @@ uint8 _sys_readseq(uint8 *filename, long fpos) {
 	uint8 i;
 
 	digitalWrite(LED, HIGH^LEDinv);
-	if (_sys_extendfile((char*)filename, fpos))
-		f = SD.open((char*)filename, O_READ);
+	f = SD.open((char*)filename, O_READ);
 	if (f) {
 		if (f.seek(fpos)) {
 			for (i = 0; i < BlkSZ; ++i)

--- a/RunCPM/abstraction_vstudio.h
+++ b/RunCPM/abstraction_vstudio.h
@@ -238,6 +238,7 @@ uint8 _sys_readrand(uint8 *filename, long fpos) {
 	uint8 bytesread;
 	uint8 dmabuf[128];
 	uint8 i;
+	long extSize;
 
 	FILE *file = _sys_fopen_r(&filename[0]);
 	if (file != NULL) {
@@ -251,7 +252,18 @@ uint8 _sys_readrand(uint8 *filename, long fpos) {
 			}
 			result = bytesread ? 0x00 : 0x01;
 		} else {
-			result = 0x06;
+		   if (fpos >= 65536L * 128) {
+		   	result = 0x06;	// seek past 8MB (largest file size in CP/M)
+			} else {
+				_sys_fseek(file, 0, SEEK_END);
+				extSize = _sys_ftell(file);
+				// round file size up to next full logical extent
+				extSize = 16384 * ((extSize / 16384) + ((extSize % 16384) ? 1 : 0));
+				if (fpos < extSize)
+					result = 0x01;	// reading unwritten data
+				else
+					result = 0x04; // seek to unwritten extent
+			}
 		}
 		_sys_fclose(file);
 	} else {

--- a/RunCPM/disk.h
+++ b/RunCPM/disk.h
@@ -454,7 +454,8 @@ uint8 _ReadRand(uint16 fcbaddr) {
 	if (!_SelectDisk(F->dr)) {
 		_FCBtoHostname(fcbaddr, &filename[0]);
 		result = _sys_readrand(&filename[0], fpos);
-		if (!result) {	// Read succeeded, adjust FCB
+		if (result == 0 || result == 1 || result == 4) {
+			// adjust FCB unless error #6 (seek past 8MB - max CP/M file & disk size)
 			F->cr = record & 0x7F;
 			F->ex = (record >> 7) & 0x1f;
 			F->s2 = (record >> 12) & 0xff;


### PR DESCRIPTION
Update FCB's CR, EX and S2 fields in _ReadRand() unless an error # 6 is returned from _sys_readrand (seek past physical end of disk). Updating in the case of a #1 or #4 error mimcs CP/M's behaviour and allows a program to use _ReadRand as a sort of seek() call to position for a subsequent Seq Write. It's a little weird, but it seems that at least one program out there does that kind of thing.

Removed _sys_extendfile() calls from _sys_read* functions. WordStar 4.0 actually does a random read of record# 65530 after it finishes printing a file, and the source file was being inflated to 8MB. Gulp!