### PR TITLE
Warm boot needs to reload CCP and BDOS, not just CCP

### DIFF
--- a/RunCPM/abstraction_posix.h
+++ b/RunCPM/abstraction_posix.h
@@ -38,9 +38,17 @@ uint8 _findnext(uint8 isdir) {
 	uint32 bytes;
 
 	if (allExtents && fileRecords) {
+		// _SearchFirst was called with '?' in the FCB's EX field, so
+		// we need to return all file extents.
+		// The last found file was large enough that in CP/M it would
+		// have another directory entry, so mock up the next entry
+		// for the file.
 		_mockupDirEntry();
 		result = 0;
 	} else {
+		// Either we're only interested in the first directory entry
+		// for each file, or the previously found file has had the
+		// required number of dierctory entries returned already.
 		dir[0] = filename[0];
 		if (allUsers)
 			dir[2] = '?';
@@ -66,6 +74,11 @@ uint8 _findnext(uint8 isdir) {
 						if (bytes & (BlkSZ - 1)) {
 							bytes = (bytes & ~(BlkSZ - 1)) + BlkSZ;
 						}
+						// calculate the number of 128 byte records and 16K
+						// extents for this file. _mockupDirEntry will use
+						// these values to populate the returned directory
+						// entry, and decrement the # of records and extents
+						// left to process in the file.
 						fileRecords = bytes / BlkSZ;
 						fileExtents = fileRecords / BlkEX + ((fileRecords & (BlkEX - 1)) ? 1 : 0);
 						firstFreeAllocBlock = firstBlockAfterDir;

--- a/RunCPM/cpm.h
+++ b/RunCPM/cpm.h
@@ -22,8 +22,6 @@ unsigned long time_start = 0;
 unsigned long time_now = 0;
 #endif
 
-static uint8 firstTime = TRUE;
-
 void _PatchCPM(void) {
 	uint16 i;
 
@@ -44,76 +42,73 @@ void _PatchCPM(void) {
 	_RamWrite(0x0005, JP);
 	_RamWrite16(0x0006, BDOSjmppage + 0x06);
 
-	if (firstTime) {
-		//**********  Patch CP/M Version into the memory so the CCP can see it
-		_RamWrite16(BDOSjmppage, 0x1600);
-		_RamWrite16(BDOSjmppage + 2, 0x0000);
-		_RamWrite16(BDOSjmppage + 4, 0x0000);
+	//**********  Patch CP/M Version into the memory so the CCP can see it
+	_RamWrite16(BDOSjmppage, 0x1600);
+	_RamWrite16(BDOSjmppage + 2, 0x0000);
+	_RamWrite16(BDOSjmppage + 4, 0x0000);
 
-		// Patches in the BDOS jump destination
-		_RamWrite(BDOSjmppage + 6, JP);
-		_RamWrite16(BDOSjmppage + 7, BDOSpage);
+	// Patches in the BDOS jump destination
+	_RamWrite(BDOSjmppage + 6, JP);
+	_RamWrite16(BDOSjmppage + 7, BDOSpage);
 
-		// Patches in the BDOS page content
-		_RamWrite(BDOSpage, INa);
-		_RamWrite(BDOSpage + 1, 0x00);
-		_RamWrite(BDOSpage + 2, RET);
+	// Patches in the BDOS page content
+	_RamWrite(BDOSpage, INa);
+	_RamWrite(BDOSpage + 1, 0x00);
+	_RamWrite(BDOSpage + 2, RET);
 
-		// Patches in the BIOS jump destinations
-		for (i = 0; i < 0x36; i = i + 3) {
-			_RamWrite(BIOSjmppage + i, JP);
-			_RamWrite16(BIOSjmppage + i + 1, BIOSpage + i);
-		}
+	// Patches in the BIOS jump destinations
+	for (i = 0; i < 0x36; i = i + 3) {
+		_RamWrite(BIOSjmppage + i, JP);
+		_RamWrite16(BIOSjmppage + i + 1, BIOSpage + i);
+	}
 
-		// Patches in the BIOS page content
-		for (i = 0; i < 0x36; i = i + 3) {
-			_RamWrite(BIOSpage + i, OUTa);
-			_RamWrite(BIOSpage + i + 1, i & 0xff);
-			_RamWrite(BIOSpage + i + 2, RET);
-		}
+	// Patches in the BIOS page content
+	for (i = 0; i < 0x36; i = i + 3) {
+		_RamWrite(BIOSpage + i, OUTa);
+		_RamWrite(BIOSpage + i + 1, i & 0xff);
+		_RamWrite(BIOSpage + i + 2, RET);
+	}
 
-		//**********  Patch CP/M (fake) Disk Paramater Table after the BDOS call entry  **********
-		i = DPBaddr;
-		_RamWrite(i++, 64);  		/* spt - Sectors Per Track */
-		_RamWrite(i++, 0);
-		_RamWrite(i++, 5);   		/* bsh - Data allocation "Block Shift Factor" */
-		_RamWrite(i++, 0x1F);		/* blm - Data allocation Block Mask */
-		_RamWrite(i++, 1);   		/* exm - Extent Mask */
-		_RamWrite(i++, 0xFF);		/* dsm - Total storage capacity of the disk drive */
-		_RamWrite(i++, 0x07);
-		_RamWrite(i++, 255); 		/* drm - Number of the last directory entry */
-		_RamWrite(i++, 3);
-		_RamWrite(i++, 0xFF);		/* al0 */
-		_RamWrite(i++, 0x00);		/* al1 */
-		_RamWrite(i++, 0);   		/* cks - Check area Size */
-		_RamWrite(i++, 0);
-		_RamWrite(i++, 0x02);		/* off - Number of system reserved tracks at the beginning of the ( logical ) disk */
-		_RamWrite(i++, 0x00);
-		blockShift = _RamRead(DPBaddr + 2);
-		blockMask = _RamRead(DPBaddr + 3);
-		extentMask = _RamRead(DPBaddr + 4);
-		numAllocBlocks = _RamRead16((DPBaddr + 5)) + 1;
-		extentsPerDirEntry = extentMask + 1;
+	//**********  Patch CP/M (fake) Disk Paramater Table after the BDOS call entry  **********
+	i = DPBaddr;
+	_RamWrite(i++, 64);  		/* spt - Sectors Per Track */
+	_RamWrite(i++, 0);
+	_RamWrite(i++, 5);   		/* bsh - Data allocation "Block Shift Factor" */
+	_RamWrite(i++, 0x1F);		/* blm - Data allocation Block Mask */
+	_RamWrite(i++, 1);   		/* exm - Extent Mask */
+	_RamWrite(i++, 0xFF);		/* dsm - Total storage capacity of the disk drive */
+	_RamWrite(i++, 0x07);
+	_RamWrite(i++, 255); 		/* drm - Number of the last directory entry */
+	_RamWrite(i++, 3);
+	_RamWrite(i++, 0xFF);		/* al0 */
+	_RamWrite(i++, 0x00);		/* al1 */
+	_RamWrite(i++, 0);   		/* cks - Check area Size */
+	_RamWrite(i++, 0);
+	_RamWrite(i++, 0x02);		/* off - Number of system reserved tracks at the beginning of the ( logical ) disk */
+	_RamWrite(i++, 0x00);
+	blockShift = _RamRead(DPBaddr + 2);
+	blockMask = _RamRead(DPBaddr + 3);
+	extentMask = _RamRead(DPBaddr + 4);
+	numAllocBlocks = _RamRead16((DPBaddr + 5)) + 1;
+	extentsPerDirEntry = extentMask + 1;
 
-		// figure out the number of the first allocation block
-		// after the directory for the phoney allocation block
-		// list in _findnext()
-		firstBlockAfterDir = 0;
+	// figure out the number of the first allocation block
+	// after the directory for the phoney allocation block
+	// list in _findnext()
+	firstBlockAfterDir = 0;
+	i = 0x80;
+	while (_RamRead(DPBaddr + 9) & i) {
+		firstBlockAfterDir++;
+		i >>= 1;
+	}
+	if (_RamRead(DPBaddr + 9) == 0xFF) {
 		i = 0x80;
-		while (_RamRead(DPBaddr + 9) & i) {
+		while (_RamRead(DPBaddr + 10) & i) {
 			firstBlockAfterDir++;
 			i >>= 1;
 		}
-		if (_RamRead(DPBaddr + 9) == 0xFF) {
-			i = 0x80;
-			while (_RamRead(DPBaddr + 10) & i) {
-				firstBlockAfterDir++;
-				i >>= 1;
-			}
-		}
-		physicalExtentBytes = logicalExtentBytes * (extentMask + 1);
-		firstTime = FALSE;
 	}
+	physicalExtentBytes = logicalExtentBytes * (extentMask + 1);
 }
 
 #ifdef DEBUGLOG

--- a/RunCPM/cpm.h
+++ b/RunCPM/cpm.h
@@ -89,7 +89,6 @@ void _PatchCPM(void) {
 		_RamWrite(i++, 0);
 		_RamWrite(i++, 0x02);		/* off - Number of system reserved tracks at the beginning of the ( logical ) disk */
 		_RamWrite(i++, 0x00);
-		_RamWrite(i++, 0x20);		/* spt - Sectors Per Track */
 		blockShift = _RamRead(DPBaddr + 2);
 		blockMask = _RamRead(DPBaddr + 3);
 		extentMask = _RamRead(DPBaddr + 4);

--- a/RunCPM/cpu.h
+++ b/RunCPM/cpu.h
@@ -2340,7 +2340,7 @@ static inline void Z80run(void) {
 			break;
 
 		case 0xa1:      /* AND C */
-			AF = andTable[((AF >> 8)& BC) & 0xff];
+			AF = andTable[((AF >> 8) & BC) & 0xff];
 			break;
 
 		case 0xa2:      /* AND D */
@@ -2348,7 +2348,7 @@ static inline void Z80run(void) {
 			break;
 
 		case 0xa3:      /* AND E */
-			AF = andTable[((AF >> 8)& DE) & 0xff];
+			AF = andTable[((AF >> 8) & DE) & 0xff];
 			break;
 
 		case 0xa4:      /* AND H */
@@ -2356,11 +2356,11 @@ static inline void Z80run(void) {
 			break;
 
 		case 0xa5:      /* AND L */
-			AF = andTable[((AF >> 8)& HL) & 0xff];
+			AF = andTable[((AF >> 8) & HL) & 0xff];
 			break;
 
 		case 0xa6:      /* AND (HL) */
-			AF = andTable[((AF >> 8)& GET_BYTE(HL)) & 0xff];
+			AF = andTable[((AF >> 8) & GET_BYTE(HL)) & 0xff];
 			break;
 
 		case 0xa7:      /* AND A */
@@ -3147,12 +3147,12 @@ static inline void Z80run(void) {
 				break;
 
 			case 0xa5:      /* AND IXL */
-				AF = andTable[((AF >> 8)& IX) & 0xff];
+				AF = andTable[((AF >> 8) & IX) & 0xff];
 				break;
 
 			case 0xa6:      /* AND (IX+dd) */
 				adr = IX + (int8)RAM_PP(PC);
-				AF = andTable[((AF >> 8)& GET_BYTE(adr)) & 0xff];
+				AF = andTable[((AF >> 8) & GET_BYTE(adr)) & 0xff];
 				break;
 
 			case 0xac:      /* XOR IXH */
@@ -3423,7 +3423,7 @@ static inline void Z80run(void) {
 			break;
 
 		case 0xe6:      /* AND nn */
-			AF = andTable[((AF >> 8)& RAM_PP(PC)) & 0xff];
+			AF = andTable[((AF >> 8) & RAM_PP(PC)) & 0xff];
 			break;
 
 		case 0xe7:      /* RST 20H */
@@ -4384,12 +4384,12 @@ static inline void Z80run(void) {
 				break;
 
 			case 0xa5:      /* AND IYL */
-				AF = andTable[((AF >> 8)& IY) & 0xff];
+				AF = andTable[((AF >> 8) & IY) & 0xff];
 				break;
 
 			case 0xa6:      /* AND (IY+dd) */
 				adr = IY + (int8)RAM_PP(PC);
-				AF = andTable[((AF >> 8)& GET_BYTE(adr)) & 0xff];
+				AF = andTable[((AF >> 8) & GET_BYTE(adr)) & 0xff];
 				break;
 
 			case 0xac:      /* XOR IYH */


### PR DESCRIPTION
Aggressive programs (like Turbo Pascal 3.01A, apparently) can overwrite not only the CCP but parts of the BDOS as well. I'd modified _PatchCPM() to only set up the BDOS vectors on a cold boot, which worked fine for ZCPR3.3 but failed with DR's CCP. So I've just removed the "if (first_time)" test and let _PatchCPM() reinitialize everything.