### PR TITLE
_sys_findnext() wasn't setting fileExtentsUsed to zero on a new file.…

### DIFF
--- a/RunCPM/abstraction_arduino.h
+++ b/RunCPM/abstraction_arduino.h
@@ -344,6 +344,7 @@ uint8 _findnext(uint8 isdir) {
 					}
 					fileRecords = bytes / BlkSZ;
 					fileExtents = fileRecords / BlkEX + ((fileRecords & (BlkEX - 1)) ? 1 : 0);
+					fileExtentsUsed = 0;
 					firstFreeAllocBlock = firstBlockAfterDir;
 					_mockupDirEntry();
 				} else {

--- a/RunCPM/abstraction_posix.h
+++ b/RunCPM/abstraction_posix.h
@@ -81,6 +81,7 @@ uint8 _findnext(uint8 isdir) {
 						// left to process in the file.
 						fileRecords = bytes / BlkSZ;
 						fileExtents = fileRecords / BlkEX + ((fileRecords & (BlkEX - 1)) ? 1 : 0);
+						fileExtentsUsed = 0;
 						firstFreeAllocBlock = firstBlockAfterDir;
 						_mockupDirEntry();
 					} else {

--- a/RunCPM/abstraction_vstudio.h
+++ b/RunCPM/abstraction_vstudio.h
@@ -360,6 +360,7 @@ uint8 _findnext(uint8 isdir) {
 				}
 				fileRecords = bytes / BlkSZ;
 				fileExtents = fileRecords / BlkEX + ((fileRecords & (BlkEX - 1)) ? 1 : 0);
+				fileExtentsUsed = 0;
 				firstFreeAllocBlock = firstBlockAfterDir;
 				_mockupDirEntry();
 			} else {


### PR DESCRIPTION
… When the previously found file had more than one directory entry, its number of extents was leaking through to the next found file.