### PR TITLE
Bump R register once per M1 cycle for programs that depend on R incrementing

### DIFF
--- a/RunCPM/cpu.h
+++ b/RunCPM/cpu.h
@@ -31,7 +31,7 @@ const char* iLogTxt;
 
 /* increase R by val (to correctly implement refresh counter) if enabled */
 #ifdef DO_INCR
-#define INCR(val) IR = (IR & ~0x7f) | ((IR + (val)) & 0x7f)
+#define INCR(val) IR = (IR & ~0x3f) | ((IR + (val)) & 0x3f)
 #else
 #define INCR(val) ;
 #endif

--- a/RunCPM/cpu.h
+++ b/RunCPM/cpu.h
@@ -29,8 +29,12 @@ char iLogBuffer[256];
 const char* iLogTxt;
 #endif
 
-/* increase R by val (to correctly implement refresh counter) */
+/* increase R by val (to correctly implement refresh counter) if enabled */
+#ifdef DO_INCR
 #define INCR(val) IR = (IR & ~0x7f) | ((IR + (val)) & 0x7f)
+#else
+#define INCR(val) ;
+#endif
 
 /*
 	Functions needed by the soft CPU implementation

--- a/RunCPM/cpu.h
+++ b/RunCPM/cpu.h
@@ -29,6 +29,9 @@ char iLogBuffer[256];
 const char* iLogTxt;
 #endif
 
+/* increase R by val (to correctly implement refresh counter) */
+#define INCR(val) IR = (IR & ~0x7f) | ((IR + (val)) & 0x7f)
+
 /*
 	Functions needed by the soft CPU implementation
 */
@@ -1479,6 +1482,7 @@ static inline void Z80run(void) {
 #endif
 
 		PCX = PC;
+		INCR(1); /* Add one M1 cycle to refresh counter */
 
 #ifdef iDEBUG
 		iLogFile = fopen("iDump.log", "a");
@@ -2575,6 +2579,7 @@ static inline void Z80run(void) {
 			break;
 
 		case 0xcb:      /* CB prefix */
+			INCR(1); /* Add one M1 cycle to refresh counter */
 			adr = HL;
 			switch ((op = GET_BYTE(PC)) & 7) {
 
@@ -2809,6 +2814,7 @@ static inline void Z80run(void) {
 			break;
 
 		case 0xdd:      /* DD prefix */
+			INCR(1); /* Add one M1 cycle to refresh counter */
 			switch (RAM_PP(PC)) {
 
 			case 0x09:      /* ADD IX,BC */
@@ -3473,6 +3479,7 @@ static inline void Z80run(void) {
 			break;
 
 		case 0xed:      /* ED prefix */
+			INCR(1); /* Add one M1 cycle to refresh counter */
 			switch (RAM_PP(PC)) {
 
 			case 0x40:      /* IN B,(C) */
@@ -3863,6 +3870,7 @@ static inline void Z80run(void) {
 				if (BC == 0)
 					BC = 0x10000;
 				do {
+					INCR(2); /* Add two M1 cycles to refresh counter */
 					acu = RAM_PP(HL);
 					PUT_BYTE_PP(DE, acu);
 				} while (--BC);
@@ -3876,6 +3884,7 @@ static inline void Z80run(void) {
 				if (BC == 0)
 					BC = 0x10000;
 				do {
+					INCR(1); /* Add one M1 cycle to refresh counter */
 					temp = RAM_PP(HL);
 					op = --BC != 0;
 					sum = acu - temp;
@@ -3894,6 +3903,7 @@ static inline void Z80run(void) {
 				if (temp == 0)
 					temp = 0x100;
 				do {
+					INCR(1); /* Add one M1 cycle to refresh counter */
 					acu = cpu_in(LOW_REGISTER(BC));
 					PUT_BYTE(HL, acu);
 					++HL;
@@ -3908,6 +3918,7 @@ static inline void Z80run(void) {
 				if (temp == 0)
 					temp = 0x100;
 				do {
+					INCR(1); /* Add one M1 cycle to refresh counter */
 					acu = GET_BYTE(HL);
 					cpu_out(LOW_REGISTER(BC), acu);
 					++HL;
@@ -3922,6 +3933,7 @@ static inline void Z80run(void) {
 				if (BC == 0)
 					BC = 0x10000;
 				do {
+					INCR(2); /* Add two M1 cycles to refresh counter */
 					acu = RAM_MM(HL);
 					PUT_BYTE_MM(DE, acu);
 				} while (--BC);
@@ -3935,6 +3947,7 @@ static inline void Z80run(void) {
 				if (BC == 0)
 					BC = 0x10000;
 				do {
+					INCR(1); /* Add one M1 cycle to refresh counter */
 					temp = RAM_MM(HL);
 					op = --BC != 0;
 					sum = acu - temp;
@@ -3953,6 +3966,7 @@ static inline void Z80run(void) {
 				if (temp == 0)
 					temp = 0x100;
 				do {
+					INCR(1); /* Add one M1 cycle to refresh counter */
 					acu = cpu_in(LOW_REGISTER(BC));
 					PUT_BYTE(HL, acu);
 					--HL;
@@ -3967,6 +3981,7 @@ static inline void Z80run(void) {
 				if (temp == 0)
 					temp = 0x100;
 				do {
+					INCR(1); /* Add one M1 cycle to refresh counter */
 					acu = GET_BYTE(HL);
 					cpu_out(LOW_REGISTER(BC), acu);
 					--HL;
@@ -4046,6 +4061,7 @@ static inline void Z80run(void) {
 			break;
 
 		case 0xfd:      /* FD prefix */
+			INCR(1); /* Add one M1 cycle to refresh counter */
 			switch (RAM_PP(PC)) {
 
 			case 0x09:      /* ADD IY,BC */

--- a/RunCPM/globals.h
+++ b/RunCPM/globals.h
@@ -6,6 +6,9 @@
 #include <ctype.h>
 #endif
 
+/* Definition for enabling incrementing the R register for each M1 cycle */
+#define DO_INCR
+
 /* Definitions for enabling PUN: and LST: devices */
 #define USE_PUN	// The pun.txt and lst.txt files will appear on drive A: user 0
 #define USE_LST


### PR DESCRIPTION
Some CP/M applications read the refresh register and use the results as a random number seed.  In one specific case, not only is there no randomness if you don't increment R on each M1 cycle (like a real Z-80), the program actually hangs because it's waiting to read a value greater than 1.

This patch adds an increment to R at each point in the instruction dispatch that corresponds to incrementing R once for every M1 cycle that would have been generated in a real Z-80.  A simple random number generator application does generate random numbers and the aforementioned CP/M application runs as expected.