### PR TITLE
Update version number for R register increment feature

### DIFF
--- a/RunCPM/globals.h
+++ b/RunCPM/globals.h
@@ -22,8 +22,8 @@
 #define LogName "RunCPM.log"
 
 /* RunCPM version for the greeting header */
-#define VERSION	"5.4"
-#define VersionBCD 0x54
+#define VERSION	"5.5"
+#define VersionBCD 0x55
 
 /* Definition of which CCP to use (must define only one) */
 #define CCP_INTERNAL	// If this is defined, an internal CCP will emulated


### PR DESCRIPTION
I completely forgot to bump up the version number from my previous pull request.  I noticed this when I went to write some documentation about which version of RunCPM would be able to run ADVENTUR.COM (it depends on the incrementing R register feature).