### PR TITLE
Don't forget to initscr()

### DIFF
--- a/RunCPM/abstraction_posix.h
+++ b/RunCPM/abstraction_posix.h
@@ -489,6 +489,7 @@ void _host_init(int argc, char* argv[]) {
 static struct termios _old_term, _new_term;
 
 void _console_init(void) {
+	(void)initscr();
 	tcgetattr(0, &_old_term);
 
 	_new_term = _old_term;


### PR DESCRIPTION
`initscr()` is supposed to be the very first call into the curses library. The documentation for ncurses and for NetBSD's own version of curses says so.

On NetBSD, initscr() is what actually initializes a whole bunch of pointers underneath the hood (they start out as NULL). Without this change, we're dereferencing NULL pointers and engaging in all sorts of other wrong behavior. 