### PR TITLE
When line editing ^W moves to EOL

### DIFF
--- a/RunCPM/ccp.h
+++ b/RunCPM/ccp.h
@@ -550,9 +550,10 @@ uint8 _ccp_ext(void) {
 
         if (found) {
             //_puts(".SUB file found!\n");
-            
+            int i, j;
+
             //move FCB's (CmdFCB --> ParFCB --> SecFCB)
-            for (int i = 0; i < 16; i++) {
+            for (i = 0; i < 16; i++) {
                 //ParFCB to SecFCB
                 _RamWrite(SecFCB + i, _RamRead(ParFCB + i));
                 //CmdFCB to ParFCB
@@ -564,7 +565,7 @@ uint8 _ccp_ext(void) {
             //put 'SUBMIT.COM' in CmdFCB
             char *str = "SUBMIT  COM";
             int s = (int)strlen(str);
-            for (int i = 0; i < s; i++) {
+            for (i = 0; i < s; i++) {
                 _RamWrite(CmdFCB + i + 1, str[i]);
             }
             
@@ -585,6 +586,44 @@ uint8 _ccp_ext(void) {
                         }
                     }
                 }
+            }
+            if (found) {
+#if 0
+                    blen = _RamRead(defDMA);
+                    printf("\n\r before[0:%.2u]:'", blen);
+                    for (i = 1; i <= blen; i++) {
+                        _putcon(_RamRead(defDMA + i));
+                    }
+                    printf("'.");
+#endif
+                //insert "@" into command buffer
+                //note: this is so the rest will be parsed correctly
+                char *str = "@";
+                uint8 cnt = strlen(str);
+                blen = _RamRead(defDMA);
+
+                if (blen + cnt > cmdLen) {
+                    blen = cmdLen - cnt;
+                }
+                //save the new length
+                _RamWrite(defDMA, blen + cnt);
+
+                //now move everything up cnt bytes
+                for (i = blen, j = i + cnt; j >= cnt; i--, j--) {
+                    _RamWrite(defDMA + 1 + j, _RamRead(defDMA + 1 + i));
+                }
+                //and put our string into the buffer
+                for (i = 0; i < cnt; i++) {
+                    _RamWrite(defDMA + 1 + i, str[i]);
+                }
+#if 0
+                    blen = _RamRead(defDMA);
+                    printf("\n\r  after[0:%.2u]:'", blen);
+                    for (i = 1; i <= blen; i++) {
+                        _putcon(_RamRead(defDMA + i));
+                    }
+                    printf("'.");
+#endif
             }
         }
     }

--- a/RunCPM/cpm.h
+++ b/RunCPM/cpm.h
@@ -545,8 +545,8 @@ void _Bios(void) {
 
 		default: {
 #ifdef DEBUG    // Show unimplemented BIOS calls only when debugging
-			_puts(	"\r\nUnimplemented BIOS call.\r\n");
-			_puts(	"C = 0x");
+			_puts("\r\nUnimplemented BIOS call.\r\n");
+			_puts("C = 0x");
 			_puthex8(ch);
 			_puts("\r\n");
 #endif // ifdef DEBUG
@@ -756,17 +756,17 @@ void _Bdos(void) {
 
 #ifdef DEBUG
                 if (chr == 4) {                             // ^D - DEBUG
-                    Debug = 1
+                    Debug = 1;
 
                     printf("\r\n curCol: %u, chrsCnt: %u, chrsMax: %u", curCol, chrsCnt, chrsMax);
                     _puts("#\r\n  ");
-                    reType = chrsCnt;
-                    postBS = chrsCnt - curCol;
+                    curCol = 0;
+                    reType = postBS = chrsCnt;
                 }
 #endif // ifdef DEBUG
 
                 if (chr == 5) {                             // ^E - goto beginning of next line
-                    _puts("\n");
+                    _putcon('\n');
                     preBS = curCol;
                     reType = postBS = chrsCnt;
                 }
@@ -844,14 +844,15 @@ void _Bdos(void) {
 
                 if (chr == 23) {                        // ^W - recall last command
                     if (!curCol) {      //if at beginning of command line
-                        if (last[0]) {  //and there's a last command
+                        uint8 lastCnt = last[0];
+                        if (lastCnt) {  //and there's a last command
                             //restore last command
-                            for (j = 0; j <= chrsCnt; j++) {
+                            for (j = 0; j <= lastCnt; j++) {
                                 _RamWrite((chrsCntIdx + j) & 0xFFFF, last[j]);
                             }
-                            //retype to greater of chrsCnt & last[0]
-                            reType = (chrsCnt > last[0]) ? chrsCnt : last[0];
-                            chrsCnt = last[0];  //this is the restored length
+                            //retype to greater of chrsCnt & lastCnt
+                            reType = (chrsCnt > lastCnt) ? chrsCnt : lastCnt;
+                            chrsCnt = lastCnt;  //this is the restored length
                             //backspace to end of restored command
                             postBS = reType - chrsCnt;
                         } else {
@@ -1337,8 +1338,8 @@ void _Bdos(void) {
 		 */
 		default: {
 #ifdef DEBUG    // Show unimplemented BDOS calls only when debugging
-			_puts(	"\r\nUnimplemented BDOS call.\r\n");
-			_puts(	"C = 0x");
+			_puts("\r\nUnimplemented BDOS call.\r\n");
+			_puts("C = 0x");
 			_puthex8(ch);
 			_puts("\r\n");
 #endif // ifdef DEBUG

--- a/RunCPM/cpm.h
+++ b/RunCPM/cpm.h
@@ -850,8 +850,9 @@ void _Bdos(void) {
                                 _RamWrite((chrsCntIdx + j) & 0xFFFF, last[j]);
                             }
                             //retype & backspace to greater of chrsCnt & last[0]
-                            reType = postBS = (chrsCnt > last[0]) ? chrsCnt : last[0];
+                            reType = (chrsCnt > last[0]) ? chrsCnt : last[0];
                             chrsCnt = last[0];
+                            postBS = reType - chrsCnt;
                         } else {
                             _putcon('\007');  //ring the bell
                         }

--- a/RunCPM/cpm.h
+++ b/RunCPM/cpm.h
@@ -849,9 +849,10 @@ void _Bdos(void) {
                             for (j = 0; j <= chrsCnt; j++) {
                                 _RamWrite((chrsCntIdx + j) & 0xFFFF, last[j]);
                             }
-                            //retype & backspace to greater of chrsCnt & last[0]
+                            //retype to greater of chrsCnt & last[0]
                             reType = (chrsCnt > last[0]) ? chrsCnt : last[0];
-                            chrsCnt = last[0];
+                            chrsCnt = last[0];  //this is the restored length
+                            //backspace to end of restored command
                             postBS = reType - chrsCnt;
                         } else {
                             _putcon('\007');  //ring the bell


### PR DESCRIPTION
PR #153 implemented ^W incorrectly: when ^W restored previous command cursor was left at BOL instead of EOL.
