### PR TITLE
Get rid of compiler warning

### DIFF
--- a/RunCPM/cpm.h
+++ b/RunCPM/cpm.h
@@ -712,7 +712,7 @@ void _Bdos(void) {
 
             static uint8 *last = 0;
             if (!last) {
-                last = calloc(1, 256);    //allocate one (for now!)
+                last = (uint8*)calloc(1,256);    //allocate one (for now!)
             }
 
 #ifdef PROFILE


### PR DESCRIPTION
cpm.h:715:30: warning: invalid conversion from 'void*' to 'uint8*' {aka 'unsigned char*'} [-fpermissive]
  715 |                 last = calloc(1, 256);    //allocate one (for now!)