### PR TITLE
End ncurses-windows correctly

### DIFF
--- a/RunCPM/abstraction_posix.h
+++ b/RunCPM/abstraction_posix.h
@@ -506,6 +506,7 @@ void _console_init(void) {
 
 void _console_reset(void) {
 	tcsetattr(0, TCSANOW, &_old_term);
+	(void)endwin();
 }
 
 int _kbhit(void) {


### PR DESCRIPTION
End ncurses-windows correctly and get a proper working prompt after exiting RunCPm under Linux/POSIX