### PR TITLE
get rid of the bool-compile error under Linux (armbian)

### DIFF
--- a/RunCPM/abstraction_posix.h
+++ b/RunCPM/abstraction_posix.h
@@ -5,6 +5,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h> 
 #include <sys/stat.h>
 #include <ncurses.h>
 #include <poll.h>


### PR DESCRIPTION
doenst affect the compile under TDM-GCC in windows :)

The bool-compile-error - like in:

In file included from main.c:54:
ccp.h:23:1: error: unknown type name ‘bool’
   23 | bool sFlag = FALSE;             // Submit Flag