### PR TITLE
Enable optimizations for MacOS

### DIFF
--- a/RunCPM/Makefile.macosx
+++ b/RunCPM/Makefile.macosx
@@ -9,9 +9,9 @@ CC = gcc
 #CC = gcc -DDEBUG=1 -DDEBUGLOG=1
 
 # Flags to pass to the compiler - add "-g" to include debug information
-CFLAGS = -Wall -O0 -fPIC -Wno-unused-variable -DHASLUA
+CFLAGS = -Wall -O3 -fPIC -Wno-unused-variable -DHASLUA
 #uncomment next line to include debug symbols
-#CFLAGS+=-ggdb
+CFLAGS+=-ggdb
 
 # Flags to pass to the linker
 LDFLAGS = -lm -ldl


### PR DESCRIPTION
Enabled optimizations (-O3) for MacOS.   Test run of ZEXALL on my Mac went from 56 to 21 seconds.