### PR TITLE
Add rebuild to make options

### DIFF
--- a/RunCPM/Makefile
+++ b/RunCPM/Makefile
@@ -18,9 +18,13 @@ clean:
 build:
 	$(MAKE) -f Makefile.$(SYS) all
 
+rebuild:
+	$(MAKE) -f Makefile.$(SYS) rebuild
+
 none:
 	@echo "To build RunCPM issue 'make PLATFORM build'."
 	@echo "To clean RunCPM issue 'make PLATFORM clean'."
+	@echo "To clean,then build RunCPM issue 'make PLATFORM rebuild'."
 	@echo "Valid platforms are: $(PLATS)"
 
 .PHONY: all $(PLATS) clean build none

--- a/RunCPM/Makefile.mingw
+++ b/RunCPM/Makefile.mingw
@@ -23,7 +23,7 @@ LUABUILD = $(MAKE) -C lua mingw
 LUACLEAN = $(MAKE) -C lua clean
 
 # Clean up program
-RM = rm -f
+RM = del /Q
 
 #------------------------------------------------------------------------
 

--- a/RunCPM/lua/Makefile
+++ b/RunCPM/lua/Makefile
@@ -13,7 +13,13 @@ LIBS= -lm $(SYSLIBS) $(MYLIBS)
 
 AR= ar rcu
 RANLIB= ranlib
-RM= rm -f
+ifeq ($(OS),Windows_NT)
+    # If on Windows, use DEL
+    RM = del /Q
+else
+    # If on Linux, use RM
+    RM = rm -f
+endif
 UNAME= uname
 
 SYSCFLAGS=

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,11 @@ For Linux and FreeBSD the "ncurses.h" header file (and library) is required and 
 On Mac OS X, install it using "brew install ncurses".<br>
 The "readline.h" header file is also required on Linux/FreeBSD. On some linuxes it is called "libreadline-dev".<br>
 
+All makefile options:
+  `make yyy build`: Compiles RunCPM.  Only recompiles changed files.
+  `make yyy clean`: Deletes all object files.  Doesn't recompile.
+  `make yyy rebuild`: Performs clean, then build.  Required when alternating compiling for different platforms.
+
 Anyone having issues building with homebrew 'binutils' on Mac should check this issue: https://github.com/MockbaTheBorg/RunCPM/issues/136<br>
 
 ## Getting Started

--- a/readme.md
+++ b/readme.md
@@ -64,9 +64,9 @@ On Mac OS X, install it using "brew install ncurses".<br>
 The "readline.h" header file is also required on Linux/FreeBSD. On some linuxes it is called "libreadline-dev".<br>
 
 All makefile options:
-  `make yyy build`: Compiles RunCPM.  Only recompiles changed files.
-  `make yyy clean`: Deletes all object files.  Doesn't recompile.
-  `make yyy rebuild`: Performs clean, then build.  Required when alternating compiling for different platforms.
+* `make yyy build`: Compiles RunCPM.  Only recompiles changed files.
+* `make yyy clean`: Deletes all object files.  Doesn't recompile.
+* `make yyy rebuild`: Performs clean, then build.  Required when alternating compiling for different platforms.
 
 Anyone having issues building with homebrew 'binutils' on Mac should check this issue: https://github.com/MockbaTheBorg/RunCPM/issues/136<br>
 


### PR DESCRIPTION
Added rebuild to make options
Updated documentation to include clean and rebuild make options 
Uses DEL instead of RM for mingw build
Uses DEL instead of RM on Windows platforms for LUA build